### PR TITLE
add github actions

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,14 @@
+name: Test extension with nix
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v16
+      - run: nix flake check
+      - run: nix build

--- a/flake.nix
+++ b/flake.nix
@@ -10,34 +10,35 @@
   outputs = { self, flake-utils, nixpkgs, ... }:
     let
       attrs = nixpkgs.lib.importJSON ./package.json;
-      name = attrs.name;
+      inherit (attrs) name version;
+      vsix = "${name}-${version}.vsix";
     in
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        vsix = "${attrs.name}-${attrs.version}.vsix";
-        pkgs = import nixpkgs { inherit system; };
-      in
-      {
-        defaultPackage = self.packages.${system}.vsix;
+    flake-utils.lib.simpleFlake {
+      inherit name self nixpkgs;
+      overlay = this: prev: {
+        ${name} = {
+          vsix = prev.mkYarnPackage {
+            src = ./.;
+            name = vsix;
+            buildPhase = ''
+              # fix Error: ENOENT: no such file or directory, stat '/build/$HASH-source/deps/${name}/${name}
+              rm deps/${name}/${name}
+              # fix Warning: Using '*' activation is usually a bad idea as it impacts performance.
+              echo y |
+              yarn run --offline vsce package --yarn
+            '';
+            installPhase = ''
+              mv deps/${name}/${vsix} $out
+            '';
+            distPhase = "true";
+          };
 
-        packages.vsix = pkgs.mkYarnPackage {
-          src = ./.;
-          name = vsix;
-          buildPhase = ''
-            # fix Error: ENOENT: no such file or directory, stat '/build/$HASH-source/deps/${name}/${name}
-            rm deps/${name}/${name}
-            # fix Warning: Using '*' activation is usually a bad idea as it impacts performance.
-            echo y |
-            yarn run --offline vsce package --yarn
-          '';
-          installPhase = ''
-            mv deps/${name}/${vsix} $out
-          '';
-          distPhase = "true";
-        };
+          defaultPackage = this.${name}.vsix;
 
-        devShell = pkgs.mkShell {
-          inputsFrom = [ self.defaultPackage.${system} ];
+          devShell = prev.mkShell {
+            inputsFrom = [ this.${name}.defaultPackage ];
+          };
         };
-      });
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,33 @@
           devShell = prev.mkShell {
             inputsFrom = [ this.${name}.defaultPackage ];
           };
+
+          checks = {
+            compile = prev.mkYarnPackage {
+              src = ./.;
+              name = "${name}-${version}.compile";
+              buildPhase = "yarn run compile";
+              installPhase = "mkdir $out";
+              distPhase = "true";
+            };
+
+            lint = prev.mkYarnPackage {
+              src = ./.;
+              name = "${name}-${version}.lint";
+              buildPhase = "yarn run lint";
+              installPhase = "mkdir $out";
+              distPhase = "true";
+            };
+
+            # TODO: @vscode/test-electron downloads vscode to run the tests in...
+            # test = prev.mkYarnPackage {
+            #   src = ./.;
+            #   name = "${name}-${version}.test";
+            #   buildPhase = "yarn run test";
+            #   installPhase = "mkdir $out";
+            #   distPhase = "true";
+            # };
+          };
         };
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
             compile = prev.mkYarnPackage {
               src = ./.;
               name = "${name}-${version}.compile";
-              buildPhase = "yarn run compile";
+              buildPhase = "yarn run --offline compile";
               installPhase = "mkdir $out";
               distPhase = "true";
             };
@@ -51,19 +51,22 @@
             lint = prev.mkYarnPackage {
               src = ./.;
               name = "${name}-${version}.lint";
-              buildPhase = "yarn run lint";
+              buildPhase = "yarn run --offline lint";
               installPhase = "mkdir $out";
               distPhase = "true";
             };
 
-            # TODO: @vscode/test-electron downloads vscode to run the tests in...
-            # test = prev.mkYarnPackage {
-            #   src = ./.;
-            #   name = "${name}-${version}.test";
-            #   buildPhase = "yarn run test";
-            #   installPhase = "mkdir $out";
-            #   distPhase = "true";
-            # };
+            test = prev.mkYarnPackage {
+              src = ./.;
+              name = "${name}-${version}.test";
+              postConfigure = ''
+                mkdir -p deps/${name}/.vscode-test/vscode-linux-x64-${prev.vscode.version}/
+                ln -s ${prev.vscode}/bin deps/${name}/.vscode-test/vscode-linux-x64-${prev.vscode.version}/VSCode-linux-x64
+              '';
+              buildPhase = "yarn run --offline test";
+              installPhase = "mkdir $out";
+              distPhase = "true";
+            };
           };
         };
       };

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -4,12 +4,13 @@ import { runTests } from '@vscode/test-electron'
 
 async function main() {
 	try {
+		const version = '1.62.3'
 		const extensionDevelopmentPath = path.resolve(__dirname, '../../')
 		const extensionTestsPath = path.resolve(__dirname, './suite/index')
 		const workspacePath = path.resolve(__dirname, '../../test/workspace')
 		const disableExtensions = '--disable-extensions'
 		const launchArgs = [workspacePath, disableExtensions]
-		await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs })
+		await runTests({ version, extensionDevelopmentPath, extensionTestsPath, launchArgs })
 	} catch (err) {
 		console.error('Failed to run tests')
 		process.exit(1)


### PR DESCRIPTION
two things of note:

1. i failed to add checks to the old flake.nix, `nix flake check` resulted in failures to build something for aarch64-linux on this x86_64-linux system. switching to `simpleFlake` helped and i think i might prefer that new definition (i didn't get simpleFlake to work before). what do you think?

    the resulting derivations before:
    ```
    git+file:///home/mkhl/src/github.com/direnv/direnv-vscode?ref=main&rev=f46ef8d149e1da082c17a9d88e67d12e826ec27a
    ├───defaultPackage
    │   ├───aarch64-darwin: package 'direnv-0.3.0.vsix'
    │   ├───aarch64-linux: package 'direnv-0.3.0.vsix'
    │   ├───i686-linux: package 'direnv-0.3.0.vsix'
    │   ├───x86_64-darwin: package 'direnv-0.3.0.vsix'
    │   └───x86_64-linux: package 'direnv-0.3.0.vsix'
    ├───devShell
    │   ├───aarch64-darwin: development environment 'nix-shell'
    │   ├───aarch64-linux: development environment 'nix-shell'
    │   ├───i686-linux: development environment 'nix-shell'
    │   ├───x86_64-darwin: development environment 'nix-shell'
    │   └───x86_64-linux: development environment 'nix-shell'
    └───packages
        ├───aarch64-darwin
        │   └───vsix: package 'direnv-0.3.0.vsix'
        ├───aarch64-linux
        │   └───vsix: package 'direnv-0.3.0.vsix'
        ├───i686-linux
        │   └───vsix: package 'direnv-0.3.0.vsix'
        ├───x86_64-darwin
        │   └───vsix: package 'direnv-0.3.0.vsix'
        └───x86_64-linux
            └───vsix: package 'direnv-0.3.0.vsix'
    ```
    and after:
    ```
    git+file:///home/mkhl/src/github.com/direnv/direnv-vscode?ref=HEAD&rev=f1d92292cd50c499469a64fdff9283292ffbccaa
    ├───checks
    │   └───x86_64-linux
    │       ├───compile: derivation 'direnv-0.3.0.compile'
    │       └───lint: derivation 'direnv-0.3.0.lint'
    ├───defaultPackage
    │   └───x86_64-linux: package 'direnv-0.3.0.vsix'
    ├───devShell
    │   └───x86_64-linux: development environment 'nix-shell'
    └───legacyPackages
        └───x86_64-linux
            ├───defaultPackage: package 'direnv-0.3.0.vsix'
            ├───devShell: package 'nix-shell'
            └───vsix: package 'direnv-0.3.0.vsix'
    ```

2. i still can't get the actual tests to run because they start off by downloading the most recent version of vscode. we can pin the version and download it beforehand but i have no idea how to integrate that into the nix build. any ideas?