### PR TITLE
feat: add configuration for automatic extension host restarts

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Show the number of changed environment variables"
+				},
+				"direnv.restart.automatic": {
+					"type": "boolean",
+					"default": false,
+					"description": "Automatically restart extension host upon environment changes"
 				}
 			}
 		},

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,4 +66,7 @@ export default section([root], {
 	status: {
 		showChangesCount: value(true),
 	},
+	restart: {
+		automatic: value(false),
+	},
 })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -310,10 +310,15 @@ class Direnv implements vscode.Disposable {
 	}
 
 	private async onDidUpdate() {
-		const choice = await vscode.window.showWarningMessage(
-			`direnv: Environment updated. Restart extensions?`,
-			'Restart',
-		)
+		let choice
+		if (config.restart.automatic.get()) {
+			choice = 'Restart'
+		} else {
+			choice = await vscode.window.showWarningMessage(
+				`direnv: Environment updated. Restart extensions?`,
+				'Restart',
+			)
+		}
 		if (choice === 'Restart') {
 			if (vscode.env.remoteName === undefined) {
 				await vscode.commands.executeCommand('workbench.action.restartExtensionHost')


### PR DESCRIPTION
This adds a configuration option that skips the prompt to restart the extension host if direnv needs to change the environment. It is defaulted to false, so it only takes affect if a user (or workspace) set the option to true.

The reason for adding this change is because I'd like the direnv restart to be transparent to developers working on my repositories, and with this option I can set it to true in a `.vscode/settings.json` file.