### PR TITLE
fix: Avoid disposing watchers if there is no env to update

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -166,6 +166,9 @@ class Direnv implements vscode.Disposable {
 
 	private updateEnvironment(data?: Data) {
 		if (data === undefined) return
+		// Avoid updating the environment & cleaning out watchers if data is empty
+		// such as when `direnv.dump()` is called twice without changes
+		if (data.size === 0) return
 		data.forEach((value, key) => {
 			if (!this.backup.has(key)) {
 				// keep the oldest value


### PR DESCRIPTION
I discovered that watchers were cleared when the extension host was restarted. I traced this to calling `direnv.dump()` twice when the extension host was restarted, and the 2nd time it returned nothing which just results in an empty map.

Since the empty map wasn't guarded, this resulted in the watchers being disposed and no new watchers were setup.