### PR TITLE
feat: allow configuring extra environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,14 @@
 		"configuration": {
 			"title": "direnv",
 			"properties": {
+				"direnv.extraEnv": {
+					"type": "object",
+					"scope": "machine-overridable",
+					"description": "Environment variables to set before running direnv",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
 				"direnv.path.executable": {
 					"type": "string",
 					"default": "direnv",

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,7 @@ function section<T extends object>(path: string[], object: T): Settings<T> {
 }
 
 export default section([root], {
+	extraEnv: value({}),
 	path: {
 		executable: value('direnv'),
 	},

--- a/src/direnv.ts
+++ b/src/direnv.ts
@@ -59,6 +59,7 @@ async function direnv(args: string[], env?: NodeJS.ProcessEnv): Promise<Stdio> {
 			...process.env,
 			['TERM']: 'dumb',
 			...env,
+			...config.extraEnv.get(),
 		},
 	}
 	const command = config.path.executable.get()


### PR DESCRIPTION
Before this patch, the environment where direnv was running couldn't be configured.

It's common to provide different dev shells when working with Nix. A common pattern to let the user which shell they want to use is to use a pre-exported environment variable and add a `.envrc` similar to:

```sh
use flake $DIRENV_USE_FLAKE_ARGS --impure --accept-flake-config
```

With this improvement, now you can record any environment variables to be forced before running any direnv command.

As a result, you can even combine this with multiple workspaces and have different dev shells for the same project. In my case, this is useful for developing different versions (with different dependencies) of the same app from within the same metarepo. To do that, just add these 2 files:

```json5
// v1.code-workspace
{"settings":{"direnv.extraEnv":{"DIRENV_USE_FLAKE_ARGS":".#shellForV1"}}}
```

```json5
// v2.code-workspace
{"settings":{"direnv.extraEnv":{"DIRENV_USE_FLAKE_ARGS":".#shellForV2"}}}
```

Fix https://github.com/direnv/direnv-vscode/issues/514.

@moduon MT-1075