### PR TITLE
Unset direnv-defined terminal environment variables

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,7 +169,7 @@ class Direnv implements vscode.Disposable {
 				this.backup.set(key, process.env[key])
 			}
 
-			this.environment.replace(key, value ?? '') // can't unset, set to empty instead
+			this.updateTerminalEnv(key, value)
 			this.updateProcessEnv(key, value)
 		}
 		this.updateWatchers(data)
@@ -191,6 +191,10 @@ class Direnv implements vscode.Disposable {
 		} else {
 			process.env[key] = value
 		}
+	}
+
+	private updateTerminalEnv(key: string, value: string | null) {
+		this.environment.replace(key, value ?? '') // can't unset, set to empty instead
 	}
 
 	private async load() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -170,28 +170,27 @@ class Direnv implements vscode.Disposable {
 			}
 
 			this.environment.replace(key, value ?? '') // can't unset, set to empty instead
-			if (value === null) {
-				// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-				delete process.env[key]
-			} else {
-				process.env[key] = value
-			}
+			this.updateProcessEnv(key, value)
 		}
 		this.updateWatchers(data)
 	}
 
 	private resetEnvironment(data?: Data) {
 		for (const [key, value] of this.backup) {
-			if (value === undefined) {
-				// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-				delete process.env[key]
-			} else {
-				process.env[key] = value
-			}
+			this.updateProcessEnv(key, value)
 		}
 		this.backup.clear()
 		this.environment.clear()
 		this.updateWatchers(data)
+	}
+
+	private updateProcessEnv(key: string, value: string | null | undefined) {
+		if (value === null || value === undefined) {
+			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+			delete process.env[key]
+		} else {
+			process.env[key] = value
+		}
 	}
 
 	private async load() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -194,7 +194,11 @@ class Direnv implements vscode.Disposable {
 	}
 
 	private updateTerminalEnv(key: string, value: string | null) {
-		this.environment.replace(key, value ?? '') // can't unset, set to empty instead
+		if (value === null && this.backup.get(key) === undefined) {
+			this.environment.delete(key)
+		} else {
+			this.environment.replace(key, value ?? '') // can't unset, set to empty instead
+		}
 	}
 
 	private async load() {


### PR DESCRIPTION
When a variable was originally undefined *and* we're removing it from a workspace again
then we can also remove its modification in the terminal EnvironmentVariableCollection.

Closes #527