### PR TITLE
Add direnv.watchForChanges setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+### Added
+- Add direnv.watchForChanges setting
 
 ## [0.16.0] - 2024-01-18
 ### Added

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
 						"type": "string"
 					}
 				},
+				"direnv.watchForChanges": {
+					"type": "boolean",
+					"default": true,
+					"description": "Automatically reload environment on file changes"
+				},
 				"direnv.path.executable": {
 					"type": "string",
 					"default": "direnv",

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,7 @@ function section<T extends object>(path: string[], object: T): Settings<T> {
 
 export default section([root], {
 	extraEnv: value({}),
+	watchForChanges: value(true),
 	path: {
 		executable: value('direnv'),
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -186,9 +186,11 @@ class Direnv implements vscode.Disposable {
 
 	private updateWatchers(data?: Data) {
 		this.watchers.dispose()
-		this.watchers = vscode.Disposable.from(
-			...direnv.watchedPaths(data).map((it) => this.createWatcher(it)),
-		)
+		if (config.watchForChanges.get()) {
+			this.watchers = vscode.Disposable.from(
+				...direnv.watchedPaths(data).map((it) => this.createWatcher(it)),
+			)
+		}
 	}
 
 	private updateEnvironment(data?: Data) {


### PR DESCRIPTION
This setting could be useful for folks not wanting the constant "Reload environment" question warning popping up when they edit their direnv-watched files in VSCode. I, for example, don't want the extension to constantly reload the environment after every tiny change auto-saved by the editor.

It plays nicely with `direnv.restart.automatic` set to `true`. I just execute reload command manually and the environment is ready + extensions are restarted, without any popup, saving my wrist :smile:.

[direnv-0.16.0.vsix.gz](https://github.com/direnv/direnv-vscode/files/14487872/direnv-0.16.0.vsix.gz)
