### PR TITLE
bump version to node 20 and vscode 1.91.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "0BSD",
 			"devDependencies": {
 				"@types/mocha": "^10.0.7",
-				"@types/node": "16.x",
+				"@types/node": "20.x",
 				"@types/sinon": "^17.0.3",
 				"@types/vscode": "1.71.x",
 				"@typescript-eslint/eslint-plugin": "^7.15.0",
@@ -29,7 +29,7 @@
 				"typescript": "^5.5.3"
 			},
 			"engines": {
-				"vscode": "^1.71.0"
+				"vscode": "^1.91.0"
 			}
 		},
 		"node_modules/@azure/abort-controller": {
@@ -938,11 +938,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.101",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.101.tgz",
-			"integrity": "sha512-AAsx9Rgz2IzG8KJ6tXd6ndNkVcu+GYB6U/SnFAaokSPNx2N7dcIIfnighYUNumvj6YS2q39Dejz5tT0NCV7CWA==",
+			"version": "20.14.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+			"integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
 			"dev": true,
-			"license": "MIT"
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/@types/sinon": {
 			"version": "17.0.3",
@@ -6857,6 +6859,12 @@
 			"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"url": "https://github.com/direnv/direnv-vscode"
 	},
 	"engines": {
-		"vscode": "^1.71.0"
+		"vscode": "^1.91.0"
 	},
 	"categories": [
 		"Other"
@@ -134,7 +134,7 @@
 		"package": "vsce package --allow-star-activation",
 		"vscode:prepublish": "run-s \"build -- --minify {@}\" --",
 		"clean": "rimraf ./out ./dist",
-		"build": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --platform=node --target=node16 --external:vscode",
+		"build": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --platform=node --target=node20 --external:vscode",
 		"eslint": "eslint --cache --cache-location ./.cache/eslint/ .",
 		"prettier": "prettier --cache --cache-location ./.cache/prettier/ .",
 		"compile:source": "run-s \"build -- --sourcemap {@}\" --",
@@ -152,7 +152,7 @@
 	},
 	"devDependencies": {
 		"@types/mocha": "^10.0.7",
-		"@types/node": "16.x",
+		"@types/node": "20.x",
 		"@types/sinon": "^17.0.3",
 		"@types/vscode": "1.71.x",
 		"@typescript-eslint/eslint-plugin": "^7.15.0",


### PR DESCRIPTION
This PR bumps the esbuild target to node20 and sets the minimum vscode engine version to 1.91.0. This recent update to vscode bricked my `direnv` extension (it gets stuck on always loading in my project). 

Building and installing with this patch seems to have resolved it. Sorry, I am not sure why the tests are failing. Hope this helps!

```
Version: 1.91.0
Commit: ea1445cc7016315d0f5728f8e8b12a45dc0a7286
Date: 2024-07-01T18:53:23.353Z
Electron: 29.4.0
ElectronBuildId: 9728852
Chromium: 122.0.6261.156
Node.js: 20.9.0
V8: 12.2.281.27-electron.0
OS: Darwin arm64 23.5.0
```
```
direnv --version
2.34.0
```