### PR TITLE
Update tests to start passing again

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
           npm run package -- --out "${{ env.artifact_name }}"
 
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: direnv-vscode
           path: ${{ env.artifact_name }}

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -41,10 +41,6 @@ export async function runSuite(workspaceRoot: string, testRoot: string, testPatt
 		await vscode.commands.executeCommand('workbench.action.closeAllEditors')
 	}
 
-	async function closeWorkspace() {
-		await vscode.commands.executeCommand('workbench.action.closeFolder')
-	}
-
 	async function resetExtension() {
 		await vscode.commands.executeCommand('direnv.reset')
 	}
@@ -68,9 +64,6 @@ export async function runSuite(workspaceRoot: string, testRoot: string, testPatt
 				await closeTabs()
 				await removeWatched()
 				await blockWorkspace()
-			},
-			async afterAll() {
-				await closeWorkspace()
 			},
 		},
 	})


### PR DESCRIPTION
I'm doing some development for a potential future PR, and noticed the tests were failing on GH Actions for two reasons:

1. The Upload job fails because [`actions/upload-artifact@v3` has been deprecated in favor of `@v4`](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) and now refuses to run. I bumped the version.
2. Several test suites were failing because closing the workspace folder at the end of each test suite run causes the extension host to restart (see also microsoft/vscode#224593). I updated the test suites to no longer do this.